### PR TITLE
Improve visible PDF signature capabilities

### DIFF
--- a/poppler/Annot.cc
+++ b/poppler/Annot.cc
@@ -4997,19 +4997,6 @@ void AnnotAppearanceBuilder::drawSignatureFieldText(const GooString &text, const
     const double textmargin = borderWidth * 2;
     const double textwidth = width - 2 * textmargin;
 
-    // Print a background image.
-    if (imageResourceRef != Ref::INVALID()) {
-        static const char *imageResourceId = "SigImg";
-        setChildDictEntryValue(resourcesDict, "XObject", imageResourceId, imageResourceRef, xref);
-
-        Matrix matrix = { 1.0, 0.0, 0.0, 1.0, 0.0, 0.0 };
-        matrix.scale(width, height);
-        static const char *IMG_TMPL = "\nq {0:.1g} {1:.1g} {2:.1g} {3:.1g} {4:.1g} {5:.1g} cm /{6:s} Do Q\n";
-        const GooString *imgBuffer = GooString::format(IMG_TMPL, matrix.m[0], matrix.m[1], matrix.m[2], matrix.m[3], matrix.m[4], matrix.m[5], imageResourceId);
-        append(imgBuffer->c_str());
-        delete imgBuffer;
-    }
-
     // create a Helvetica fake font
     GfxFont *font = createAnnotDrawFont(xref, resourcesDict, da.getFontName().getName());
 

--- a/poppler/Annot.h
+++ b/poppler/Annot.h
@@ -603,6 +603,7 @@ private:
     bool drawText(const GooString *text, const GooString *da, const GfxResources *resources, const AnnotBorder *border, const AnnotAppearanceCharacs *appearCharacs, const PDFRectangle *rect, bool multiline, int comb, int quadding,
                   bool txField, bool forceZapfDingbats, XRef *xref, bool password, Dict *resourcesDict, const char *defaultFallback = "Helvetica");
     void drawArrowPath(double x, double y, const Matrix &m, int orientation = 1);
+    void drawBackgroundImage(const Ref imageResourceRef, const PDFRectangle *rect, XRef *xref, Dict *resourcesDict);
 
     GooString *appearBuf;
 };

--- a/poppler/PDFDoc.cc
+++ b/poppler/PDFDoc.cc
@@ -2209,3 +2209,193 @@ bool PDFDoc::sign(const char *saveFilename, const char *certNickname, const char
 
     return false;
 }
+
+struct PDFDoc::NewSignatureData::NewSignatureDataPrivate
+{
+    NewSignatureDataPrivate() = default;
+
+    std::string certNickname;
+    std::string password;
+    int page;
+    PDFRectangle boundingRectangle;
+    GooString signatureText;
+    GooString signatureLeftText;
+    GooString reason;
+    GooString location;
+    double fontSize = 10.0;
+    double leftFontSize = 20.0;
+    AnnotColor fontColor = AnnotColor(0.8, 0.3, 0.2);
+    AnnotColor borderColor = AnnotColor(0.8, 0.3, 0.2);
+    double borderWidth = 1.5;
+    AnnotColor backgroundColor = AnnotColor(0.1982);
+
+    GooString partialName = GooString("Signature229");
+    std::string imagePath = "";
+};
+
+PDFDoc::NewSignatureData::NewSignatureData() : d(new NewSignatureDataPrivate()) { }
+
+PDFDoc::NewSignatureData::~NewSignatureData()
+{
+    delete d;
+}
+
+const char* PDFDoc::NewSignatureData::certNickname() const
+{
+    return d->certNickname.c_str();
+}
+
+void PDFDoc::NewSignatureData::setCertNickname(const char* certNickname)
+{
+    d->certNickname = std::string(certNickname);
+}
+
+const char* PDFDoc::NewSignatureData::password() const
+{
+    return d->password.c_str();
+}
+
+void PDFDoc::NewSignatureData::setPassword(const char* password)
+{
+    d->password = std::string(password);
+}
+
+GooString* PDFDoc::NewSignatureData::fieldPartialName() const
+{
+    return &(d->partialName);
+}
+
+void PDFDoc::NewSignatureData::setFieldPartialName(GooString* name)
+{
+    d->partialName.Set(name);
+}
+
+int PDFDoc::NewSignatureData::page()
+{
+    return d->page;
+}
+
+void PDFDoc::NewSignatureData::setPage(int page)
+{
+    d->page = page;
+}
+
+const PDFRectangle PDFDoc::NewSignatureData::boundingRectangle() const
+{
+    return d->boundingRectangle;
+}
+
+void PDFDoc::NewSignatureData::setBoundingRectangle(const PDFRectangle &rect)
+{
+    d->boundingRectangle = rect;
+}
+
+const GooString* PDFDoc::NewSignatureData::signatureText() const
+{
+    return &(d->signatureText);
+}
+
+void PDFDoc::NewSignatureData::setSignatureText(const GooString &text)
+{
+    d->signatureText.Set(&text);
+}
+
+const GooString* PDFDoc::NewSignatureData::signatureLeftText() const
+{
+    return &(d->signatureLeftText);
+}
+
+void PDFDoc::NewSignatureData::setSignatureLeftText(const GooString &text)
+{
+    d->signatureLeftText.Set(&text);
+}
+
+double PDFDoc::NewSignatureData::fontSize()
+{
+    return d->fontSize;
+}
+
+void PDFDoc::NewSignatureData::setFontSize(double fontSize)
+{
+    d->fontSize = fontSize;
+}
+
+double PDFDoc::NewSignatureData::leftFontSize()
+{
+    return d->leftFontSize;
+}
+
+void PDFDoc::NewSignatureData::setLeftFontSize(double fontSize)
+{
+    d->leftFontSize = fontSize;
+}
+
+AnnotColor PDFDoc::NewSignatureData::fontColor() const
+{
+    return d->fontColor;
+}
+
+void PDFDoc::NewSignatureData::setFontColor(const AnnotColor &color)
+{
+    d->fontColor = color;
+}
+
+AnnotColor PDFDoc::NewSignatureData::borderColor() const
+{
+    return d->borderColor;
+}
+
+double PDFDoc::NewSignatureData::borderWidth()
+{
+    return d->borderWidth;
+}
+
+void PDFDoc::NewSignatureData::setBorderWidth(double width)
+{
+    d->borderWidth = width;
+}
+
+void PDFDoc::NewSignatureData::setBorderColor(const AnnotColor &color)
+{
+    d->borderColor = color;
+}
+
+AnnotColor PDFDoc::NewSignatureData::backgroundColor() const
+{
+    return d->backgroundColor;
+}
+
+void PDFDoc::NewSignatureData::setBackgroundColor(const AnnotColor &color)
+{
+    d->backgroundColor = color;
+}
+
+const GooString* PDFDoc::NewSignatureData::reason() const
+{
+    return &(d->reason);
+}
+
+void PDFDoc::NewSignatureData::setReason(const GooString &reason)
+{
+    d->reason.Set(&reason);
+}
+
+const GooString* PDFDoc::NewSignatureData::location() const
+{
+    return &(d->location);
+}
+
+void PDFDoc::NewSignatureData::setLocation(const GooString &location)
+{
+    d->location.Set(&location);
+}
+
+const std::string PDFDoc::NewSignatureData::imagePath() const
+{
+    return d->imagePath;
+}
+
+void PDFDoc::NewSignatureData::setImagePath(const std::string &imagePath)
+{
+    d->imagePath = imagePath;
+}

--- a/poppler/PDFDoc.cc
+++ b/poppler/PDFDoc.cc
@@ -2166,6 +2166,7 @@ bool PDFDoc::sign(const char *saveFilename, NewSignatureData &data, const GooStr
     std::unique_ptr<::FormFieldSignature> field = std::make_unique<::FormFieldSignature>(this, Object(annotObj.getDict()), ref, nullptr, nullptr);
     field->setCustomAppearanceContent(*data.signatureText());
     field->setCustomAppearanceLeftContent(*data.signatureLeftText());
+    field->setCustomAppearanceLeftFontSize(data.leftFontSize());
     field->setImageResource(imageResourceRef);
 
     Object refObj(ref);
@@ -2179,6 +2180,10 @@ bool PDFDoc::sign(const char *saveFilename, NewSignatureData &data, const GooStr
     appearCharacs->setBackColor(std::move(backgroundColor));
     signatureAnnot->setAppearCharacs(std::move(appearCharacs));
 
+    std::unique_ptr<AnnotBorder> border(new AnnotBorderArray());
+    border->setWidth(data.borderWidth());
+    signatureAnnot->setBorder(std::move(border));
+
     signatureAnnot->generateFieldAppearance();
     signatureAnnot->updateAppearanceStream();
 
@@ -2186,10 +2191,6 @@ bool PDFDoc::sign(const char *saveFilename, NewSignatureData &data, const GooStr
     formWidget->setWidgetAnnotation(signatureAnnot);
 
     destPage->addAnnot(signatureAnnot);
-
-    std::unique_ptr<AnnotBorder> border(new AnnotBorderArray());
-    border->setWidth(data.borderWidth());
-    signatureAnnot->setBorder(std::move(border));
 
     FormWidgetSignature *fws = dynamic_cast<FormWidgetSignature *>(formWidget);
     if (fws) {

--- a/poppler/PDFDoc.h
+++ b/poppler/PDFDoc.h
@@ -339,6 +339,116 @@ public:
               std::unique_ptr<AnnotColor> &&fontColor, double borderWidth, std::unique_ptr<AnnotColor> &&borderColor, std::unique_ptr<AnnotColor> &&backgroundColor, const GooString *reason = nullptr, const GooString *location = nullptr,
               const std::string &imagePath = "", const GooString *ownerPassword = nullptr, const GooString *userPassword = nullptr);
 
+    class POPPLER_PRIVATE_EXPORT NewSignatureData
+    {
+    public:
+        NewSignatureData();
+        ~NewSignatureData();
+        NewSignatureData(const NewSignatureData &) = delete;
+        NewSignatureData &operator=(const NewSignatureData &) = delete;
+
+        const char* certNickname() const;
+        void setCertNickname(const char* certNickname);
+
+        const char* password() const;
+        void setPassword(const char* password);
+
+        /**
+         * Default: QUuid::createUuid().toString()
+         */
+        GooString* fieldPartialName() const;
+        void setFieldPartialName(GooString* name);
+
+        int page();
+        void setPage(int page);
+
+        const PDFRectangle boundingRectangle() const;
+        void setBoundingRectangle(const PDFRectangle &rect);
+
+        const GooString* signatureText() const;
+        void setSignatureText(const GooString &text);
+
+        /**
+         * If this text is not empty, the signature representation
+         * will split in two, with this text on the left and signatureText
+         * on the right
+         *
+         * \since 21.06
+         */
+        const GooString* signatureLeftText() const;
+        void setSignatureLeftText(const GooString &text);
+
+        /**
+         * Default: 10
+         */
+        double fontSize();
+        void setFontSize(double fontSize);
+
+        /**
+         * Default: 20
+         *
+         * \since 21.06
+         */
+        double leftFontSize();
+        void setLeftFontSize(double fontSize);
+
+        /**
+         * Default: red
+         */
+        AnnotColor fontColor() const;
+        void setFontColor(const AnnotColor &color);
+
+        /**
+         * border width in points
+         *
+         * Default: 1.5
+         *
+         * \since 21.05
+         */
+        double borderWidth();
+        void setBorderWidth(double width);
+
+        /**
+         * Default: red
+         */
+        AnnotColor borderColor() const;
+        void setBorderColor(const AnnotColor &color);
+
+        /**
+         * Default: QColor(240, 240, 240)
+         */
+        AnnotColor backgroundColor() const;
+        void setBackgroundColor(const AnnotColor &color);
+
+        /**
+         * Signature's property Reason.
+         *
+         * Default: an empty string.
+         *
+         * \since 21.10
+         */
+        const GooString* reason() const;
+        void setReason(const GooString &reason);
+
+        /**
+         * Signature's property Location.
+         *
+         * Default: an empty string.
+         *
+         * \since 21.10
+         */
+        const GooString* location() const;
+        void setLocation(const GooString &location);
+
+        const std::string imagePath() const;
+        void setImagePath(const std::string &imagePath);
+
+    private:
+        struct NewSignatureDataPrivate;
+        NewSignatureDataPrivate *const d;
+    };
+
+
 private:
     // insert referenced objects in XRef
     void markDictionnary(Dict *dict, XRef *xRef, XRef *countRef, unsigned int numOffset, int oldRefNum, int newRefNum, std::set<Dict *> *alreadyMarkedDicts);

--- a/poppler/PDFDoc.h
+++ b/poppler/PDFDoc.h
@@ -331,14 +331,6 @@ public:
     // scans the PDF and returns whether it contains any javascript
     bool hasJavascript();
 
-    // Arguments signatureText and signatureTextLeft are UTF-16 big endian strings with BOM.
-    // Arguments reason and location are UTF-16 big endian strings with BOM. An empty string and nullptr are acceptable too.
-    // Argument imagePath is a background image (a path to a file).
-    // sign() takes ownership of partialFieldName.
-    bool sign(const char *saveFilename, const char *certNickname, const char *password, GooString *partialFieldName, int page, const PDFRectangle &rect, const GooString &signatureText, const GooString &signatureTextLeft, double fontSize,
-              std::unique_ptr<AnnotColor> &&fontColor, double borderWidth, std::unique_ptr<AnnotColor> &&borderColor, std::unique_ptr<AnnotColor> &&backgroundColor, const GooString *reason = nullptr, const GooString *location = nullptr,
-              const std::string &imagePath = "", const GooString *ownerPassword = nullptr, const GooString *userPassword = nullptr);
-
     class POPPLER_PRIVATE_EXPORT NewSignatureData
     {
     public:
@@ -448,6 +440,11 @@ public:
         NewSignatureDataPrivate *const d;
     };
 
+    // Arguments signatureText and signatureTextLeft are UTF-16 big endian strings with BOM.
+    // Arguments reason and location are UTF-16 big endian strings with BOM. An empty string and nullptr are acceptable too.
+    // Argument imagePath is a background image (a path to a file).
+    // sign() takes ownership of partialFieldName.
+    bool sign(const char *saveFilename, NewSignatureData &data, const GooString *ownerPassword = nullptr, const GooString *userPassword = nullptr);
 
 private:
     // insert referenced objects in XRef

--- a/qt5/src/poppler-pdf-converter.cc
+++ b/qt5/src/poppler-pdf-converter.cc
@@ -145,10 +145,12 @@ bool PDFConverter::sign(const NewSignatureData &data)
     pData.setSignatureText(*gSignatureText);
     pData.setSignatureLeftText(*gSignatureLeftText);
     pData.setFontSize(data.fontSize());
+    pData.setLeftFontSize(data.leftFontSize());
     pData.setFontColor(*convertQColor(data.fontColor()));
     pData.setBorderWidth(data.borderWidth());
     pData.setBorderColor(*convertQColor(data.borderColor()));
     pData.setBackgroundColor(*convertQColor(data.backgroundColor()));
+    pData.setImagePath(data.imagePath().toStdString());
     if (reason != nullptr)
         pData.setReason(*reason.get());
     if (location != nullptr)
@@ -177,6 +179,7 @@ struct PDFConverter::NewSignatureData::NewSignatureDataPrivate
     QColor backgroundColor = QColor(240, 240, 240);
 
     QString partialName = QUuid::createUuid().toString();
+    QString imagePath;
 };
 
 PDFConverter::NewSignatureData::NewSignatureData() : d(new NewSignatureDataPrivate()) { }
@@ -334,5 +337,15 @@ QString PDFConverter::NewSignatureData::fieldPartialName() const
 void PDFConverter::NewSignatureData::setFieldPartialName(const QString &name)
 {
     d->partialName = name;
+}
+
+QString PDFConverter::NewSignatureData::imagePath() const
+{
+    return d->imagePath;
+}
+
+void PDFConverter::NewSignatureData::setImagePath(const QString &path)
+{
+    d->imagePath = path;
 }
 }

--- a/qt5/src/poppler-pdf-converter.cc
+++ b/qt5/src/poppler-pdf-converter.cc
@@ -134,6 +134,26 @@ bool PDFConverter::sign(const NewSignatureData &data)
     std::unique_ptr<GooString> gSignatureLeftText = std::unique_ptr<GooString>(QStringToUnicodeGooString(data.signatureLeftText()));
     const auto reason = std::unique_ptr<GooString>(data.reason().isEmpty() ? nullptr : QStringToUnicodeGooString(data.reason()));
     const auto location = std::unique_ptr<GooString>(data.location().isEmpty() ? nullptr : QStringToUnicodeGooString(data.location()));
+
+    // this could become void PDFConverter::NewSignatureData::toPoppler(PDFDoc::NewSignatureData*)
+    PDFDoc::NewSignatureData pData;
+    pData.setCertNickname(data.certNickname().toUtf8().constData());
+    pData.setPassword(data.password().toUtf8().constData());
+    pData.setFieldPartialName(QStringToGooString(data.fieldPartialName()));
+    pData.setPage(destPage->getNum());
+    pData.setBoundingRectangle(boundaryToPdfRectangle(destPage, data.boundingRectangle(), Annotation::FixedRotation));
+    pData.setSignatureText(*gSignatureText);
+    pData.setSignatureLeftText(*gSignatureLeftText);
+    pData.setFontSize(data.fontSize());
+    pData.setFontColor(*convertQColor(data.fontColor()));
+    pData.setBorderWidth(data.borderWidth());
+    pData.setBorderColor(*convertQColor(data.borderColor()));
+    pData.setBackgroundColor(*convertQColor(data.backgroundColor()));
+    if (reason != nullptr)
+        pData.setReason(*reason.get());
+    if (location != nullptr)
+        pData.setLocation(*location.get());
+
     return doc->sign(d->outputFileName.toUtf8().constData(), data.certNickname().toUtf8().constData(), data.password().toUtf8().constData(), QStringToGooString(data.fieldPartialName()), data.page() + 1,
                      boundaryToPdfRectangle(destPage, data.boundingRectangle(), Annotation::FixedRotation), *gSignatureText, *gSignatureLeftText, data.fontSize(), convertQColor(data.fontColor()), data.borderWidth(),
                      convertQColor(data.borderColor()), convertQColor(data.backgroundColor()), reason.get(), location.get());

--- a/qt5/src/poppler-pdf-converter.cc
+++ b/qt5/src/poppler-pdf-converter.cc
@@ -154,9 +154,7 @@ bool PDFConverter::sign(const NewSignatureData &data)
     if (location != nullptr)
         pData.setLocation(*location.get());
 
-    return doc->sign(d->outputFileName.toUtf8().constData(), data.certNickname().toUtf8().constData(), data.password().toUtf8().constData(), QStringToGooString(data.fieldPartialName()), data.page() + 1,
-                     boundaryToPdfRectangle(destPage, data.boundingRectangle(), Annotation::FixedRotation), *gSignatureText, *gSignatureLeftText, data.fontSize(), convertQColor(data.fontColor()), data.borderWidth(),
-                     convertQColor(data.borderColor()), convertQColor(data.backgroundColor()), reason.get(), location.get());
+    return doc->sign(d->outputFileName.toUtf8().constData(), pData);
 }
 
 struct PDFConverter::NewSignatureData::NewSignatureDataPrivate

--- a/qt5/src/poppler-qt5.h
+++ b/qt5/src/poppler-qt5.h
@@ -2291,6 +2291,9 @@ public:
         QString fieldPartialName() const;
         void setFieldPartialName(const QString &name);
 
+        QString imagePath() const;
+        void setImagePath(const QString &path);
+
     private:
         struct NewSignatureDataPrivate;
         NewSignatureDataPrivate *const d;

--- a/qt6/src/poppler-pdf-converter.cc
+++ b/qt6/src/poppler-pdf-converter.cc
@@ -145,10 +145,12 @@ bool PDFConverter::sign(const NewSignatureData &data)
     pData.setSignatureText(*gSignatureText);
     pData.setSignatureLeftText(*gSignatureLeftText);
     pData.setFontSize(data.fontSize());
+    pData.setLeftFontSize(data.leftFontSize());
     pData.setFontColor(*convertQColor(data.fontColor()));
     pData.setBorderWidth(data.borderWidth());
     pData.setBorderColor(*convertQColor(data.borderColor()));
     pData.setBackgroundColor(*convertQColor(data.backgroundColor()));
+    pData.setImagePath(data.imagePath().toStdString());
     if (reason != nullptr)
         pData.setReason(*reason.get());
     if (location != nullptr)
@@ -177,6 +179,7 @@ struct PDFConverter::NewSignatureData::NewSignatureDataPrivate
     QColor backgroundColor = QColor(240, 240, 240);
 
     QString partialName = QUuid::createUuid().toString();
+    QString imagePath;
 };
 
 PDFConverter::NewSignatureData::NewSignatureData() : d(new NewSignatureDataPrivate()) { }
@@ -334,5 +337,15 @@ QString PDFConverter::NewSignatureData::fieldPartialName() const
 void PDFConverter::NewSignatureData::setFieldPartialName(const QString &name)
 {
     d->partialName = name;
+}
+
+QString PDFConverter::NewSignatureData::imagePath() const
+{
+    return d->imagePath;
+}
+
+void PDFConverter::NewSignatureData::setImagePath(const QString &path)
+{
+    d->imagePath = path;
 }
 }

--- a/qt6/src/poppler-pdf-converter.cc
+++ b/qt6/src/poppler-pdf-converter.cc
@@ -134,6 +134,26 @@ bool PDFConverter::sign(const NewSignatureData &data)
     std::unique_ptr<GooString> gSignatureLeftText = std::unique_ptr<GooString>(QStringToUnicodeGooString(data.signatureLeftText()));
     const auto reason = std::unique_ptr<GooString>(data.reason().isEmpty() ? nullptr : QStringToUnicodeGooString(data.reason()));
     const auto location = std::unique_ptr<GooString>(data.location().isEmpty() ? nullptr : QStringToUnicodeGooString(data.location()));
+
+    // this could become void PDFConverter::NewSignatureData::toPoppler(PDFDoc::NewSignatureData*)
+    PDFDoc::NewSignatureData pData;
+    pData.setCertNickname(data.certNickname().toUtf8().constData());
+    pData.setPassword(data.password().toUtf8().constData());
+    pData.setFieldPartialName(QStringToGooString(data.fieldPartialName()));
+    pData.setPage(destPage->getNum());
+    pData.setBoundingRectangle(boundaryToPdfRectangle(destPage, data.boundingRectangle(), Annotation::FixedRotation));
+    pData.setSignatureText(*gSignatureText);
+    pData.setSignatureLeftText(*gSignatureLeftText);
+    pData.setFontSize(data.fontSize());
+    pData.setFontColor(*convertQColor(data.fontColor()));
+    pData.setBorderWidth(data.borderWidth());
+    pData.setBorderColor(*convertQColor(data.borderColor()));
+    pData.setBackgroundColor(*convertQColor(data.backgroundColor()));
+    if (reason != nullptr)
+        pData.setReason(*reason.get());
+    if (location != nullptr)
+        pData.setLocation(*location.get());
+
     return doc->sign(d->outputFileName.toUtf8().constData(), data.certNickname().toUtf8().constData(), data.password().toUtf8().constData(), QStringToGooString(data.fieldPartialName()), data.page() + 1,
                      boundaryToPdfRectangle(destPage, data.boundingRectangle(), Annotation::FixedRotation), *gSignatureText, *gSignatureLeftText, data.fontSize(), convertQColor(data.fontColor()), data.borderWidth(),
                      convertQColor(data.borderColor()), convertQColor(data.backgroundColor()), reason.get(), location.get());

--- a/qt6/src/poppler-pdf-converter.cc
+++ b/qt6/src/poppler-pdf-converter.cc
@@ -154,9 +154,7 @@ bool PDFConverter::sign(const NewSignatureData &data)
     if (location != nullptr)
         pData.setLocation(*location.get());
 
-    return doc->sign(d->outputFileName.toUtf8().constData(), data.certNickname().toUtf8().constData(), data.password().toUtf8().constData(), QStringToGooString(data.fieldPartialName()), data.page() + 1,
-                     boundaryToPdfRectangle(destPage, data.boundingRectangle(), Annotation::FixedRotation), *gSignatureText, *gSignatureLeftText, data.fontSize(), convertQColor(data.fontColor()), data.borderWidth(),
-                     convertQColor(data.borderColor()), convertQColor(data.backgroundColor()), reason.get(), location.get());
+    return doc->sign(d->outputFileName.toUtf8().constData(), pData);
 }
 
 struct PDFConverter::NewSignatureData::NewSignatureDataPrivate

--- a/qt6/src/poppler-qt6.h
+++ b/qt6/src/poppler-qt6.h
@@ -2067,6 +2067,9 @@ public:
         QString fieldPartialName() const;
         void setFieldPartialName(const QString &name);
 
+        QString imagePath() const;
+        void setImagePath(const QString &path);
+
     private:
         struct NewSignatureDataPrivate;
         NewSignatureDataPrivate *const d;

--- a/utils/pdfsig.cc
+++ b/utils/pdfsig.cc
@@ -358,9 +358,7 @@ int main(int argc, char *argv[])
         //pData.setLocation(/* location */ nullptr);
 
         // We don't provide a way to customize the UI from pdfsig for now
-        const bool success = doc->sign(argv[2], certNickname, pw, newSignatureFieldName.copy(), /*page*/ 1,
-                                       /*rect */ { 0, 0, 0, 0 }, /*signatureText*/ {}, /*signatureTextLeft*/ {}, /*fontSize */ 0,
-                                       /*fontColor*/ {}, /*borderWidth*/ 0, /*borderColor*/ {}, /*backgroundColor*/ {}, rs.get(), /* location */ nullptr, /* image path */ "", ownerPW.get(), userPW.get());
+        const bool success = doc->sign(argv[2], pData, ownerPW.get(), userPW.get());
         return success ? 0 : 3;
     }
 

--- a/utils/pdfsig.cc
+++ b/utils/pdfsig.cc
@@ -339,6 +339,24 @@ int main(int argc, char *argv[])
             }
         }
 
+        // this could become void PDFConverter::NewSignatureData::toPoppler(PDFDoc::NewSignatureData*)
+        PDFDoc::NewSignatureData pData;
+        pData.setCertNickname(certNickname);
+        pData.setPassword(pw);
+        pData.setFieldPartialName(newSignatureFieldName.copy());
+        pData.setPage(/*page*/ 1);
+        pData.setBoundingRectangle(/*rect */ { 0, 0, 0, 0 });
+        pData.setSignatureText(/*signatureText*/ {});
+        pData.setSignatureLeftText(/*signatureTextLeft*/ {});
+        pData.setFontSize(/*fontSize */ 0);
+        pData.setFontColor(/*fontColor*/ {});
+        pData.setBorderWidth(/*borderWidth*/ 0);
+        pData.setBorderColor(/*borderColor*/ {});
+        pData.setBackgroundColor(/*backgroundColor*/ {});
+        if (rs != nullptr)
+            pData.setReason(*rs.get());
+        //pData.setLocation(/* location */ nullptr);
+
         // We don't provide a way to customize the UI from pdfsig for now
         const bool success = doc->sign(argv[2], certNickname, pw, newSignatureFieldName.copy(), /*page*/ 1,
                                        /*rect */ { 0, 0, 0, 0 }, /*signatureText*/ {}, /*signatureTextLeft*/ {}, /*fontSize */ 0,


### PR DESCRIPTION
As far as I can tell, digitally signing a PDF document and creating a corresponding annotation widget is exceptionally rare in the open source world. I am currently working to make this feature in Okular applicable to my every day use cases. A few of the issues I encountered along the way do concern Poppler:

1. PDFDoc::sign draws a border around the signature. It's width can be controlled through the `borderWidth` parameter. However, `signatureAnnot->generateFieldAppearance()` is called before `border->setWidth(borderWidth)`, and therefore the parameter has no effect.
2. Applications cannot pass a font size to be used with `signatureLeftText` and therefore Poppler always uses its default (20).
3. Background images are only drawn if `signatureLeftText` is empty.
4. Qt applications cannot pass an `imagePath` to PDFDoc::sign as the data structure passed around doesn't have an attribute for it.

This pull request contains how I did solve these issues. First, I defined a new class `NewSignatureData`, which semantically mirrors the class `NewSignatureData` I found in the Qt APIs. Then I changed the APIs to use instances of this new class to pass signature related data to `PDFDoc::sign`, which is a breaking change to its signature. After that I changed the widget drawing, starting from `PDFDoc::sign` and into `AnnotAppearanceBuilder` to what I think yields better results:
I moved `signatureAnnot->generateFieldAppearance();` after `border->setWidth()` and changed `drawSignatureFieldText` to always draw a background image (if available), not just if `signatureLeftText` is empty.

While developing this I kept moving things back and forth between Okular and Poppler, because I had no idea what could and should be done in Poppler and what could and should be done in Okular. Ultimately the changes I did ...

* enable Qt applications to provide an additional font sized, to be used for "fancy" signatures
* enable Qt applications to provide a background image for signature widgets
* make `borderWidth` have an effect on the generated signature widget

Changing PDFDoc::sign's three line signature to a new object seems a bit arbitrary. It made things easier for me while moving things back and forth and a change is required anyways to provide the second font size. Further more, future work may see users providing their own fonts for their signatures. This is also data that would have to be passed into PDFDoc::sign ...

I understand this PR is quite unsolicited, doesn't fix any recorded issues and is not a small patch. I am happy to make adaptions before these changes can be accepted.